### PR TITLE
Fixed typo.

### DIFF
--- a/CVE-2021-21985.nse
+++ b/CVE-2021-21985.nse
@@ -122,7 +122,7 @@ validation in the Virtual SAN Health Check plug-in which is enabled by default i
         
         else 
           stdnse.debug2("vCenter returned unknow response.")
-          vul.state = vulns.STATE.UNKNOWN
+          vuln.state = vulns.STATE.UNKNOWN
     end
     return report:make_output (vuln)
 end


### PR DESCRIPTION
Fixed `vul.state` to `vuln.state` typo.